### PR TITLE
Fix path to rebar in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean deps distclean doc test compile
 
 # allow rebar binary to be set via environment variable
-REBAR ?= rebar
+REBAR ?= ./rebar
 
 all:
 	@$(REBAR) get-deps compile


### PR DESCRIPTION
Before this fix I got errors from Makefile, because path to rebar wasn't pointing to current directory (thus it was searching in PATH).