### PR TITLE
Introduce command API to EPL tracer

### DIFF
--- a/apps/epl/src/epl.erl
+++ b/apps/epl/src/epl.erl
@@ -41,7 +41,7 @@ unsubscribe(Pid) ->
     epl_tracer:unsubscribe(Pid).
 
 process_info(Pid) ->
-    epl_tracer:process_info(Pid).
+    epl_tracer:command(fun erlang:process_info/1, [Pid]).
 
 trace_pid(Pid) ->
     epl_tracer:trace_pid(Pid).


### PR DESCRIPTION
By calling `epl:command(Fun, Args)` we can call any function on monitored node.

This is what `epl:process_info` calls now under the hood:
```erlang
process_info(Pid) ->
    epl_tracer:command(fun erlang:process_info/1, [Pid]).
```

I have tested it with epl_3d plugin and it works like a charm.