### PR TITLE
Change JSON library to jsone, add JSON encoding/decoding API

### DIFF
--- a/apps/epl/rebar.config
+++ b/apps/epl/rebar.config
@@ -4,9 +4,9 @@
          {git, "git://github.com/jcomellas/getopt.git", "master"}},
         {cowboy, ".*",
          {git, "git://github.com/ninenines/cowboy.git", "0.8.5"}},
-        {ej, ".*",
-         {git, "git://github.com/erlanglab/ej.git", "master"}},
         {epl_3d, ".*",
-         {git, "git://github.com/erlanglab/epl_3d.git", "master"}}
+         {git, "git://github.com/erlanglab/epl_3d.git", "master"}},
+        {jsone, ".*",
+         {git, "git://github.com/erlanglab/jsone.git", "master"}}
        ]
 }.

--- a/apps/epl/src/epl.app.src
+++ b/apps/epl/src/epl.app.src
@@ -8,7 +8,7 @@
                   stdlib,
                   getopt,
                   cowboy,
-                  ej
+                  jsone
                  ]},
   {mod, {epl_app, []}},
   {env, []}

--- a/apps/epl/src/epl_dashboard.erl
+++ b/apps/epl/src/epl_dashboard.erl
@@ -85,10 +85,7 @@ handle_info({data, {N, T}, Proplist}, State = #state{subscribers = Subs}) ->
     Id = << (epl:to_bin(N))/binary, $:, (epl:timestamp(T))/binary >>,
     Proplist2 = [{id, Id} | Proplist1],
 
-    Data = [{<<"data">>, Proplist2},
-            {<<"topic">>, <<"system-info">>}],
-
-    JSON = ej:encode(Data),
+    JSON = epl_json:encode(Proplist2, <<"system-info">>),
 
     [Pid ! {data, JSON} || Pid <- Subs],
 

--- a/apps/epl/src/epl_dashboard_EPL.erl
+++ b/apps/epl/src/epl_dashboard_EPL.erl
@@ -38,7 +38,7 @@ init(_Options) ->
 init({tcp, http}, _Req, _Opts) ->
     [{node, Node}] = epl:lookup(node),
     [{node_settings, NodeSettings}] = epl:lookup(node_settings),
-    JSON = epl:proplist_to_json([{node_name, Node}|NodeSettings], <<"system-init">>),
+    JSON = epl_json:encode([{node_name, Node}|NodeSettings], <<"system-init">>),
     self() ! {data, JSON},
     epl_dashboard:subscribe(),
     {upgrade, protocol, cowboy_websocket}.

--- a/apps/epl/src/epl_dashboard_EPL.erl
+++ b/apps/epl/src/epl_dashboard_EPL.erl
@@ -38,7 +38,9 @@ init(_Options) ->
 init({tcp, http}, _Req, _Opts) ->
     [{node, Node}] = epl:lookup(node),
     [{node_settings, NodeSettings}] = epl:lookup(node_settings),
-    JSON = epl_json:encode([{node_name, Node}|NodeSettings], <<"system-init">>),
+    FormattedSettings = lists:foldl(fun format_node_settings/2,
+                                    #{node_name => Node}, NodeSettings),
+    JSON = epl_json:encode(FormattedSettings, <<"system-init">>),
     self() ! {data, JSON},
     epl_dashboard:subscribe(),
     {upgrade, protocol, cowboy_websocket}.
@@ -56,3 +58,19 @@ websocket_info(_Info, Req, State) ->
 
 websocket_terminate(_Reason, _Req, _State) ->
     ok.
+
+format_node_settings({K, V}, Acc) ->
+    case format_node_setting(K, V) of
+        ignore ->
+            Acc;
+        Val ->
+            maps:put(K, Val, Acc)
+    end.
+
+format_node_setting(allocated_areas, _) -> ignore;
+format_node_setting(memory, _)          -> ignore;
+format_node_setting(system_version, _)  -> ignore;
+format_node_setting(node_pid, V)        -> list_to_binary(V);
+format_node_setting(otp_release, V)     -> list_to_binary(V);
+format_node_setting(version, V)         -> list_to_binary(V);
+format_node_setting(_K, V)              -> V.

--- a/apps/epl/src/epl_json.erl
+++ b/apps/epl/src/epl_json.erl
@@ -1,0 +1,17 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% JSON encoding and decoding
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(epl_json).
+
+-export([encode/2,
+         decode/1]).
+
+encode(Term, Topic) ->
+    jsone:encode(#{<<"topic">> => Topic,
+                   <<"data">> => Term}).
+
+decode(Data) ->
+    jsone:decode(Data).

--- a/apps/epl/src/erlangpl.erl
+++ b/apps/epl/src/erlangpl.erl
@@ -15,9 +15,8 @@ main(_) ->
     ok = application:start(getopt),
     ok = application:start(ranch),
     ok = application:start(cowboy),
-    ok = application:start(ej),
+    ok = application:start(jsone),
     ok = application:start(epl),
-    ok = application:start(epl_3d),
 
     %% Start applications because escript can't take -boot argument
     %% TODO: start sasl if escript run with debug flags

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -13,7 +13,7 @@
          getopt,
          ranch,
          cowboy,
-         ej,
+         jsone,
          runtime_tools,
          epl,
          epl_3d


### PR DESCRIPTION
Basically swapped `ej` with `jsone` (also had to tune jsone a bit, add support for pids, ports, refs, funs and multi element tuples). Now all JSON encoding and decoding should happen using `epl_json:encode/2` and `epl_json:decode/1`.