### PR TITLE
Bump erlangpl-ui version to 0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,6 @@ rebar:
 	chmod +x $@
 
 build-ui:
+	rm -rf apps/epl/priv/htdocs
 	cd erlangpl-ui && yarn && yarn build && cd ../
 	mv erlangpl-ui/build apps/epl/priv/htdocs


### PR DESCRIPTION
Resolve #15. We released `erlangpl-ui` 0.1 💪 and our old UI is fully replaced! `erlangpl` 0.4 almost there.