### PR TITLE
Elixir integration

### DIFF
--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -405,7 +405,10 @@ plugins(Args) ->
 scan_plugins([Plugin | Rest], PluginApps) ->
     %% start an application if .app file exists
     %% TODO: What if there is no .app file? Shall we load .beam anyway?
-    EbinFiles = filelib:wildcard(Plugin ++ "/ebin/*"),
+    EbinPath = filename:join(Plugin, "ebin"),
+    ?INFO("Adding path ~s~n", [EbinPath]),
+    true = code:add_path(EbinPath),
+    EbinFiles = filelib:wildcard(EbinPath ++ "/*"),
     Fun = fun(File, App) ->
                   case filename:extension(File) of
                       ".app" ->
@@ -431,9 +434,6 @@ scan_plugins([], PluginApps) ->
     PluginApps.
 
 load_plugin(AppName, AppPath) ->
-    ?INFO("Adding path ~s~n", [AppPath]),
-    true = code:add_path(AppPath),
-
     %% Load all files from priv directory to ets
     PluginPrivDir = filename:join([AppPath, "../priv"]),
     filelib:fold_files(PluginPrivDir, "", true,

--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -182,7 +182,7 @@ run5(PluginApps, Args) ->
     GetHandlers = fun({_,preloaded}, Acc) ->
                           Acc;
                      ({Mod, Path}, Acc) ->
-                          case re:run(Path,"_EPL.beam\$",[global]) of
+                          case re:run(Path,"EPL.beam\$",[global]) of
                               {match,_} -> [Mod | Acc];
                               nomatch   -> Acc
                           end

--- a/bootstrap
+++ b/bootstrap
@@ -59,7 +59,13 @@ get_files() ->
 
 file_contents(Filename) ->
     {ok, Bin} = file:read_file(Filename),
-    Bin.
+    case filename:extension(Filename) of
+        ".beam" ->
+            {ok, {_, Stripped}} = beam_lib:strip(Bin),
+            Stripped;
+        _ ->
+            Bin
+    end.
 
 elixir_beams() ->
     Args = init:get_plain_arguments(),

--- a/bootstrap
+++ b/bootstrap
@@ -47,16 +47,61 @@ get_files() ->
 
     %% include all compiled modules and the .app file
     Beams = [filelib:fold_files(Dir, "\\.app$|\\.beam$", true, Fun, [])
-	     || Dir <- Apps],
+             || Dir <- Apps] ++ elixir_beams(),
 
     %% include all contents of the priv dirs
     %% except for .js.map files, which are heavy but unnecessary
     Privs = [filelib:fold_files(filename:join([Dir, "priv"]),
                                 "^((?!\\.js\\.map).)*$", true, Fun, [])
-	     || Dir <- Apps],
+             || Dir <- Apps],
 
     lists:flatten([Beams, Privs]).
 
 file_contents(Filename) ->
     {ok, Bin} = file:read_file(Filename),
     Bin.
+
+elixir_beams() ->
+    Args = init:get_plain_arguments(),
+    Path = get_elixir_ebin_path(Args),
+    case Path of
+        undefined ->
+            [];
+        Ebin ->
+            Paths = filelib:wildcard(filename:join(Ebin, "*")),
+            [read_elixir_beam(BeamPath) || BeamPath <- Paths]
+    end.
+
+get_elixir_ebin_path(Args) ->
+    ElixirRoot = find_in_args(Args),
+    case ensure_elixir_root(ElixirRoot) of
+        undefined ->
+            undefined;
+        Path ->
+            filename:join([Path, "lib", "elixir", "ebin"])
+    end.
+
+find_in_args(["--with-elixir", Path]) ->
+    filename:absname(Path);
+find_in_args([_ | Tail]) ->
+    find_in_args(Tail);
+find_in_args([]) ->
+    undefined.
+
+read_elixir_beam(Path) ->
+    Contents = file_contents(Path),
+    Filename = filename:basename(Path),
+    {filename:join(["elixir", "ebin", Filename]), Contents}.
+
+ensure_elixir_root(undefined) ->
+    undefined;
+ensure_elixir_root(Path) ->
+    AppFile = filename:join([Path, "lib", "elixir", "ebin", "elixir.app"]),
+    case filelib:is_regular(AppFile) of
+        true ->
+            Path;
+        false ->
+            io:format("ERROR: path provided to --with-elixir option is not "
+                      "Elixir root path~n"),
+            undefined
+    end.


### PR DESCRIPTION
After a bit of discussion (#22), I've made it possible to start Elixir on erlangpl node. There are two ways to achieve that:
1. Provide `--with-elixir <elixir_root>` option to `erlangpl` script - this results in prepending code path with given path and starting Elixir application
2. Provide `--with-elixir <elixir_root>` option to `bootstrap` script - this results in **embedding** Elixir directly into `erlangpl` escript. At runtime we simply start Elixir application.

In this setup it is possible to experiment with different Elixir versions - Elixir "passed" to `erlangpl` will override the one embedded in escript (due to code path being prepended - we don't touch anything else).

It seems to be working fine, although to be 100% sure I probably should implement simple Elixir plugin.

Note: path passed both to `bootstrap` or `erlangpl` needs to be Elixir **root** path, i.e. the top level repo directory ([elixir-lang/elixir](https://github.com/elixir-lang/elixir)). 

Ah, and of course there is a "minor" issue with embedding Elixir. Escript file size grows. By 2.6M. That's more than 200%. 😢 

Anyway, I encourage you try it out. Basic check would be to run `erlangpl` with `-vvv` flag and see if there is proper message in the logs: `Couldn't start Elixir` when Elixir is not embedded nor path was provided, or `Successfully loaded and started Elixir`. It works on my machine, but I'd appreciate feedback, especially with `bootstrap`.