### PR TITLE
Clean up code related to legacy UI

### DIFF
--- a/apps/epl/src/epl.erl
+++ b/apps/epl/src/epl.erl
@@ -17,8 +17,7 @@
          trace_pid/1,
          to_bin/1,
          log/3,
-         timestamp/1,
-         add_plugin_menu/1
+         timestamp/1
         ]).
 
 %% ===================================================================
@@ -79,17 +78,6 @@ timestamp(TS) ->
           io_lib:format("~.2.0w",[Mi]),
           io_lib:format("~.2.0w",[S])],
     to_bin(DT).
-
-
-add_plugin_menu(MenuItem) ->
-    IndexHtml = <<"epl/priv/htdocs/index.html">>,
-    [{_, Bin}] = ets:lookup(epl_priv, IndexHtml),
-    %% Look for predefined string in HTML source code
-    %% and add there HTML code with Plugin menu item
-    NewBin = re:replace(Bin, <<"<!--PLUGIN_MENU-->">>,
-                        <<MenuItem/binary, $&>>,
-                        [{return,binary}]),
-    ets:insert(epl_priv, {IndexHtml, NewBin}).
 
 %% ===================================================================
 %% internal functions

--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -187,13 +187,6 @@ run5(PluginApps, Args) ->
                   end,
 
     PluginModules = lists:foldl(GetHandlers, [], LoadedModules),
-    Node = epl:lookup(node),
-
-    %% Call EPL plugin callback functions to initialize plugins
-    Pids = [{M, {ok, _} = epl_sup:start_child(M, [Node])}
-            || M <- PluginModules],
-
-    ?INFO("Started plugins: ~p~n", [Pids]),
 
     %% Configure cowboy with paths to plugin module and plugin priv files
     CowboyHandlers =

--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -47,8 +47,6 @@ start(_StartType, _StartArgs) ->
     %% Try to start Elixir
     maybe_start_elixir(Args),
 
-    insert_node_name(Node),
-
     %% Start top supervisor
     {ok, Pid} = epl_sup:start_link(),
 
@@ -194,18 +192,6 @@ run5(PluginApps, Args) ->
     %% Call EPL plugin callback functions to initialize plugins
     Pids = [{M, {ok, _} = epl_sup:start_child(M, [Node])}
             || M <- PluginModules],
-
-    lists:foreach(
-      fun(M) ->
-              {ok, PluginConf} = M:init(Node),
-              case proplists:lookup(menu_item, PluginConf) of
-                  none ->
-                      ?WARN("Plugin ~p:init/1 does not return menu_item attribute~n", [M]);
-                  {menu_item, PluginMenu} ->
-                      epl:add_plugin_menu(PluginMenu)
-              end
-      end,
-      PluginModules),
 
     ?INFO("Started plugins: ~p~n", [Pids]),
 
@@ -455,15 +441,6 @@ load_plugin_priv(File, App) ->
         true ->
             App
     end.
-
-insert_node_name(Node) ->
-    IndexHtml = <<"epl/priv/htdocs/index.html">>,
-    NodeBin = list_to_binary(atom_to_list(Node)),
-    [{_, Bin}] = ets:lookup(epl_priv, IndexHtml),
-    NewBin = re:replace(Bin, <<"<!--NODE-->">>,
-                        <<NodeBin/binary, $&>>,
-                        [{return,binary}]),
-    ets:insert(epl_priv, {IndexHtml, NewBin}).
 
 maybe_start_elixir(Args) ->
     case proplists:lookup(elixir_path, Args) of

--- a/apps/epl/src/epl_dashboard_EPL.erl
+++ b/apps/epl/src/epl_dashboard_EPL.erl
@@ -8,29 +8,12 @@
 -module(epl_dashboard_EPL).
 -behaviour(cowboy_websocket_handler).
 
-%% EPL plugin callbacks
--export([start_link/1,
-         init/1]).
-
 %% cowboy_websocket_handler callbacks
 -export([init/3,
          websocket_init/3,
          websocket_handle/3,
          websocket_info/3,
          websocket_terminate/3]).
-
-%%%===================================================================
-%%% EPL plugin callbacks
-%%%===================================================================
-start_link(_Options) ->
-    {ok, spawn(fun() -> receive _ -> ok end end)}.
-
-init(_Options) ->
-    MenuItem = <<"<li class=\"glyphicons display\">",
-                 "<a href=\"/epl_dashboard.html\"><i></i><span>Dashboard</span></a>",
-                 "</li>">>,
-    Author = <<"Erlang Lab">>,
-    {ok, [{menu_item, MenuItem}, {author, Author}]}.
 
 %%%===================================================================
 %%% cowboy_websocket_handler callbacks

--- a/apps/epl/src/epl_traffic_EPL.erl
+++ b/apps/epl/src/epl_traffic_EPL.erl
@@ -7,25 +7,12 @@
 -module(epl_traffic_EPL).
 -behaviour(cowboy_websocket_handler).
 
-%% EPL plugin callbacks
--export([start_link/1,
-         init/1]).
-
 %% cowboy_websocket_handler callbacks
 -export([init/3,
          websocket_init/3,
          websocket_handle/3,
          websocket_info/3,
          websocket_terminate/3]).
-
-%%%===================================================================
-%%% EPL plugin callbacks
-%%%===================================================================
-start_link(_Options) ->
-    {ok, spawn_link(fun() -> receive _ -> ok end end)}.
-
-init(_Options) ->
-    {ok, [{menu_item, <<"">>}, {author, <<"">>}]}.
 
 %%%===================================================================
 %%% cowboy_websocket_handler callbacks

--- a/apps/epl/src/epl_version_EPL.erl
+++ b/apps/epl/src/epl_version_EPL.erl
@@ -7,23 +7,10 @@
 
 -module(epl_version_EPL).
 
-%% EPL plugin callbacks
--export([start_link/1,
-         init/1]).
-
 %% cowboy handler callbacks
 -export([init/3,
          handle/2,
          terminate/3]).
-
-%%%===================================================================
-%%% EPL plugin callbacks
-%%%===================================================================
-start_link(_Options) ->
-    {ok, spawn(fun() -> receive _ -> ok end end)}.
-
-init(_Options) ->
-    {ok, [{menu_item, <<"">>}, {author, <<"">>}]}.
 
 %%%===================================================================
 %%% cowboy handler callbacks


### PR DESCRIPTION
I have removed code which added plugin menus, inserted node names etc.

This addresses #31 a bit, but we're not showing any errors, only a page which suggests that maybe UI was not built.