### PR TITLE
Remove hardcoded port from UI and set default to 37575

### DIFF
--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -201,7 +201,7 @@ run5(PluginApps, Args) ->
                  ]),
 
     Port = case proplists:lookup(port, Args) of
-               none -> 8000;
+               none -> 37575;
                {port, N} when is_list(N) -> list_to_integer(N);
                {port, N} when is_integer(N) -> N
            end,

--- a/ui/src/sockets.js
+++ b/ui/src/sockets.js
@@ -91,8 +91,13 @@ let socketsArray = [];
 
 export const createSockets = (sockets: any) => {
   socketsArray = Object.keys(sockets).map(route => {
-    const { hostname } = window.location;
-    let ws = new WebSocket(`ws://${hostname}:8000/${route}`);
+    let { hostname, port } = window.location;
+
+    if (process.env.NODE_ENV !== 'production') {
+      port = 37575;
+    }
+
+    let ws = new WebSocket(`ws://${hostname}:${port}/${route}`);
 
     const handlers = Object.keys(sockets[route].topics).reduce(
       (acc, topic) => {


### PR DESCRIPTION
Fixes: #41 

Our default port right now is `37575` and UI gets port number from url in production while in development it's looking for default port.