### PR TITLE
Add JS code formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,13 @@
     "gzip-size": "3.0.0",
     "html-webpack-plugin": "2.24.0",
     "http-proxy-middleware": "0.17.3",
+    "husky": "^0.13.3",
     "jest": "18.1.0",
     "json-loader": "0.5.4",
+    "lint-staged": "^3.4.0",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",
+    "prettier": "^1.0.2",
     "promise": "7.1.1",
     "react-dev-utils": "^0.5.0",
     "recursive-readdir": "2.1.0",
@@ -71,6 +74,7 @@
   },
   "scripts": {
     "flow": "flow",
+    "precommit": "lint-staged",
     "coverage": "node ui/scripts/test.js --env=jsdom --coverage",
     "start": "node ui/scripts/start.js",
     "build": "node ui/scripts/build.js",
@@ -108,5 +112,11 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "plugins": []
+  "plugins": [],
+  "lint-staged": {
+    "*.js": [
+      "prettier --write --single-quote",
+      "git add"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "css-loader": "0.26.1",
     "detect-port": "1.0.1",
     "dotenv": "2.0.0",
+    "elm-format": "^0.6.1-alpha",
     "elm-webpack-loader": "^4.3.0",
     "eslint": "3.8.1",
     "eslint-config-react-app": "^0.5.1",
@@ -39,7 +40,7 @@
     "lint-staged": "^3.4.0",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",
-    "prettier": "^1.0.2",
+    "prettier": "^1.2.2",
     "promise": "7.1.1",
     "react-dev-utils": "^0.5.0",
     "recursive-readdir": "2.1.0",
@@ -116,6 +117,10 @@
   "lint-staged": {
     "*.js": [
       "prettier --write --single-quote",
+      "git add"
+    ],
+    "*.elm": [
+      "elm-format --yes",
       "git add"
     ]
   }

--- a/ui/config/env.js
+++ b/ui/config/env.js
@@ -4,30 +4,28 @@
 var REACT_APP = /^REACT_APP_/i;
 
 function getClientEnvironment(publicUrl) {
-  var raw = Object
-    .keys(process.env)
-    .filter(key => REACT_APP.test(key))
-    .reduce((env, key) => {
-      env[key] = process.env[key];
-      return env;
-    }, {
-      // Useful for determining whether we’re running in production mode.
-      // Most importantly, it switches React into the correct mode.
-      'NODE_ENV': process.env.NODE_ENV || 'development',
-      // Useful for resolving the correct path to static assets in `public`.
-      // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
-      // This should only be used as an escape hatch. Normally you would put
-      // images into the `src` and `import` them in code to get their paths.
-      'PUBLIC_URL': publicUrl
-    });
+  var raw = Object.keys(process.env).filter(key => REACT_APP.test(key)).reduce((
+    env,
+    key
+  ) => {
+    env[key] = process.env[key];
+    return env;
+  }, {
+    // Useful for determining whether we’re running in production mode.
+    // Most importantly, it switches React into the correct mode.
+    NODE_ENV: process.env.NODE_ENV || 'development',
+    // Useful for resolving the correct path to static assets in `public`.
+    // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
+    // This should only be used as an escape hatch. Normally you would put
+    // images into the `src` and `import` them in code to get their paths.
+    PUBLIC_URL: publicUrl
+  });
   // Stringify all values so we can feed into Webpack DefinePlugin
   var stringified = {
-    'process.env': Object
-      .keys(raw)
-      .reduce((env, key) => {
-        env[key] = JSON.stringify(raw[key]);
-        return env;
-      }, {})
+    'process.env': Object.keys(raw).reduce((env, key) => {
+      env[key] = JSON.stringify(raw[key]);
+      return env;
+    }, {})
   };
 
   return { raw, stringified };

--- a/ui/config/jest/cssTransform.js
+++ b/ui/config/jest/cssTransform.js
@@ -8,5 +8,5 @@ module.exports = {
   getCacheKey(fileData, filename) {
     // The output is always the same.
     return 'cssTransform';
-  },
+  }
 };

--- a/ui/config/jest/fileTransform.js
+++ b/ui/config/jest/fileTransform.js
@@ -6,5 +6,5 @@ const path = require('path');
 module.exports = {
   process(src, filename) {
     return 'module.exports = ' + JSON.stringify(path.basename(filename)) + ';';
-  },
+  }
 };

--- a/ui/config/paths.js
+++ b/ui/config/paths.js
@@ -55,8 +55,8 @@ function getPublicUrl(appPackageJson) {
 // like /todos/42/static/js/bundle.7289d.js. We have to know the root.
 function getServedPath(appPackageJson) {
   var publicUrl = getPublicUrl(appPackageJson);
-  var servedUrl = envPublicUrl ||
-    (publicUrl ? url.parse(publicUrl).pathname : '/');
+  var servedUrl =
+    envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : '/');
   return ensureSlash(servedUrl, true);
 }
 

--- a/ui/config/webpack.config.dev.js
+++ b/ui/config/webpack.config.dev.js
@@ -200,19 +200,16 @@ module.exports = {
     new WatchMissingNodeModulesPlugin(paths.appNodeModules),
 
     new CopyWebpackPlugin(
-      plugins.reduce(
-        (acc, plugin) => {
-          let tmp = [];
-          if (plugin.media)
-            tmp.push({
-              from: `${plugin.media}/`,
-              to: `${plugin.name}/`
-            });
+      plugins.reduce((acc, plugin) => {
+        let tmp = [];
+        if (plugin.media)
+          tmp.push({
+            from: `${plugin.media}/`,
+            to: `${plugin.name}/`
+          });
 
-          return acc.concat(tmp);
-        },
-        []
-      ),
+        return acc.concat(tmp);
+      }, []),
       { debug: 'info' }
     )
   ],

--- a/ui/config/webpack.config.prod.js
+++ b/ui/config/webpack.config.prod.js
@@ -237,26 +237,23 @@ module.exports = {
     }),
 
     new CopyWebpackPlugin(
-      plugins.reduce(
-        (acc, plugin) => {
-          let tmp = [];
-          if (plugin.media)
-            tmp.push({
-              from: `${plugin.media}/`,
-              to: `${plugin.name}/`
-            });
+      plugins.reduce((acc, plugin) => {
+        let tmp = [];
+        if (plugin.media)
+          tmp.push({
+            from: `${plugin.media}/`,
+            to: `${plugin.name}/`
+          });
 
-          return acc.concat(
-            tmp.concat(
-              plugin.styles.concat(plugin.scripts).map(file => ({
-                from: file.dir,
-                to: `${plugin.name}/`
-              }))
-            )
-          );
-        },
-        []
-      ),
+        return acc.concat(
+          tmp.concat(
+            plugin.styles.concat(plugin.scripts).map(file => ({
+              from: file.dir,
+              to: `${plugin.name}/`
+            }))
+          )
+        );
+      }, []),
       { debug: 'info' }
     )
   ],

--- a/ui/scripts/build.js
+++ b/ui/scripts/build.js
@@ -5,7 +5,7 @@ process.env.NODE_ENV = 'production';
 // if this file is missing. dotenv will never modify any environment variables
 // that have already been set.
 // https://github.com/motdotla/dotenv
-require('dotenv').config({silent: true});
+require('dotenv').config({ silent: true });
 
 var chalk = require('chalk');
 var fs = require('fs-extra');
@@ -77,8 +77,9 @@ recursive(paths.appBuild, (err, fileNames) => {
 
 // Print a detailed summary of build files.
 function printFileSizes(stats, previousSizeMap) {
-  var assets = stats.toJson().assets
-    .filter(asset => /\.(js|css)$/.test(asset.name))
+  var assets = stats
+    .toJson()
+    .assets.filter(asset => /\.(js|css)$/.test(asset.name))
     .map(asset => {
       var fileContents = fs.readFileSync(paths.appBuild + '/' + asset.name);
       var size = gzipSize(fileContents);
@@ -92,7 +93,8 @@ function printFileSizes(stats, previousSizeMap) {
       };
     });
   assets.sort((a, b) => b.size - a.size);
-  var longestSizeLabelLength = Math.max.apply(null,
+  var longestSizeLabelLength = Math.max.apply(
+    null,
     assets.map(a => stripAnsi(a.sizeLabel).length)
   );
   assets.forEach(asset => {
@@ -103,8 +105,11 @@ function printFileSizes(stats, previousSizeMap) {
       sizeLabel += rightPadding;
     }
     console.log(
-      '  ' + sizeLabel +
-      '  ' + chalk.dim(asset.folder + path.sep) + chalk.cyan(asset.name)
+      '  ' +
+        sizeLabel +
+        '  ' +
+        chalk.dim(asset.folder + path.sep) +
+        chalk.cyan(asset.name)
     );
   });
 }
@@ -134,9 +139,12 @@ function build(previousSizeMap) {
     }
 
     if (process.env.CI && stats.compilation.warnings.length) {
-     printErrors('Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.', stats.compilation.warnings);
-     process.exit(1);
-   }
+      printErrors(
+        'Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.',
+        stats.compilation.warnings
+      );
+      process.exit(1);
+    }
 
     console.log(chalk.green('Compiled successfully.'));
     console.log();
@@ -147,69 +155,133 @@ function build(previousSizeMap) {
     console.log();
 
     var openCommand = process.platform === 'win32' ? 'start' : 'open';
-    var appPackage  = require(paths.appPackageJson);
+    var appPackage = require(paths.appPackageJson);
     var publicUrl = paths.publicUrl;
     var publicPath = config.output.publicPath;
     var publicPathname = url.parse(publicPath).pathname;
     if (publicUrl && publicUrl.indexOf('.github.io/') !== -1) {
       // "homepage": "http://user.github.io/project"
-      console.log('The project was built assuming it is hosted at ' + chalk.green(publicPathname) + '.');
-      console.log('You can control this with the ' + chalk.green('homepage') + ' field in your '  + chalk.cyan('package.json') + '.');
+      console.log(
+        'The project was built assuming it is hosted at ' +
+          chalk.green(publicPathname) +
+          '.'
+      );
+      console.log(
+        'You can control this with the ' +
+          chalk.green('homepage') +
+          ' field in your ' +
+          chalk.cyan('package.json') +
+          '.'
+      );
       console.log();
-      console.log('The ' + chalk.cyan('build') + ' folder is ready to be deployed.');
+      console.log(
+        'The ' + chalk.cyan('build') + ' folder is ready to be deployed.'
+      );
       console.log('To publish it at ' + chalk.green(publicUrl) + ', run:');
       // If script deploy has been added to package.json, skip the instructions
       if (typeof appPackage.scripts.deploy === 'undefined') {
         console.log();
         if (useYarn) {
-          console.log('  ' + chalk.cyan('yarn') +  ' add --dev gh-pages');
+          console.log('  ' + chalk.cyan('yarn') + ' add --dev gh-pages');
         } else {
-          console.log('  ' + chalk.cyan('npm') +  ' install --save-dev gh-pages');
+          console.log(
+            '  ' + chalk.cyan('npm') + ' install --save-dev gh-pages'
+          );
         }
         console.log();
-        console.log('Add the following script in your ' + chalk.cyan('package.json') + '.');
+        console.log(
+          'Add the following script in your ' + chalk.cyan('package.json') + '.'
+        );
         console.log();
         console.log('    ' + chalk.dim('// ...'));
         console.log('    ' + chalk.yellow('"scripts"') + ': {');
         console.log('      ' + chalk.dim('// ...'));
-        console.log('      ' + chalk.yellow('"predeploy"') + ': ' + chalk.yellow('"npm run build",'));
-        console.log('      ' + chalk.yellow('"deploy"') + ': ' + chalk.yellow('"gh-pages -d build"'));
+        console.log(
+          '      ' +
+            chalk.yellow('"predeploy"') +
+            ': ' +
+            chalk.yellow('"npm run build",')
+        );
+        console.log(
+          '      ' +
+            chalk.yellow('"deploy"') +
+            ': ' +
+            chalk.yellow('"gh-pages -d build"')
+        );
         console.log('    }');
         console.log();
         console.log('Then run:');
       }
       console.log();
-      console.log('  ' + chalk.cyan(useYarn ? 'yarn' : 'npm') +  ' run deploy');
+      console.log('  ' + chalk.cyan(useYarn ? 'yarn' : 'npm') + ' run deploy');
       console.log();
     } else if (publicPath !== '/') {
       // "homepage": "http://mywebsite.com/project"
-      console.log('The project was built assuming it is hosted at ' + chalk.green(publicPath) + '.');
-      console.log('You can control this with the ' + chalk.green('homepage') + ' field in your '  + chalk.cyan('package.json') + '.');
+      console.log(
+        'The project was built assuming it is hosted at ' +
+          chalk.green(publicPath) +
+          '.'
+      );
+      console.log(
+        'You can control this with the ' +
+          chalk.green('homepage') +
+          ' field in your ' +
+          chalk.cyan('package.json') +
+          '.'
+      );
       console.log();
-      console.log('The ' + chalk.cyan('build') + ' folder is ready to be deployed.');
+      console.log(
+        'The ' + chalk.cyan('build') + ' folder is ready to be deployed.'
+      );
       console.log();
     } else {
       if (publicUrl) {
         // "homepage": "http://mywebsite.com"
-        console.log('The project was built assuming it is hosted at ' + chalk.green(publicUrl) +  '.');
-        console.log('You can control this with the ' + chalk.green('homepage') + ' field in your '  + chalk.cyan('package.json') + '.');
+        console.log(
+          'The project was built assuming it is hosted at ' +
+            chalk.green(publicUrl) +
+            '.'
+        );
+        console.log(
+          'You can control this with the ' +
+            chalk.green('homepage') +
+            ' field in your ' +
+            chalk.cyan('package.json') +
+            '.'
+        );
         console.log();
       } else {
         // no homepage
-        console.log('The project was built assuming it is hosted at the server root.');
-        console.log('To override this, specify the ' + chalk.green('homepage') + ' in your '  + chalk.cyan('package.json') + '.');
-        console.log('For example, add this to build it for GitHub Pages:')
+        console.log(
+          'The project was built assuming it is hosted at the server root.'
+        );
+        console.log(
+          'To override this, specify the ' +
+            chalk.green('homepage') +
+            ' in your ' +
+            chalk.cyan('package.json') +
+            '.'
+        );
+        console.log('For example, add this to build it for GitHub Pages:');
         console.log();
-        console.log('  ' + chalk.green('"homepage"') + chalk.cyan(': ') + chalk.green('"http://myname.github.io/myapp"') + chalk.cyan(','));
+        console.log(
+          '  ' +
+            chalk.green('"homepage"') +
+            chalk.cyan(': ') +
+            chalk.green('"http://myname.github.io/myapp"') +
+            chalk.cyan(',')
+        );
         console.log();
       }
-      console.log('The ' + chalk.cyan('build') + ' folder is ready to be deployed.');
-      console.log('You may also serve it locally with a static server:')
+      console.log(
+        'The ' + chalk.cyan('build') + ' folder is ready to be deployed.'
+      );
+      console.log('You may also serve it locally with a static server:');
       console.log();
       if (useYarn) {
-        console.log('  ' + chalk.cyan('yarn') +  ' global add pushstate-server');
+        console.log('  ' + chalk.cyan('yarn') + ' global add pushstate-server');
       } else {
-        console.log('  ' + chalk.cyan('npm') +  ' install -g pushstate-server');
+        console.log('  ' + chalk.cyan('npm') + ' install -g pushstate-server');
       }
       console.log('  ' + chalk.cyan('pushstate-server') + ' build');
       console.log('  ' + chalk.cyan(openCommand) + ' http://localhost:9000');

--- a/ui/scripts/start.js
+++ b/ui/scripts/start.js
@@ -334,12 +334,13 @@ detect(DEFAULT_PORT).then(port => {
   if (isInteractive) {
     clearConsole();
     var existingProcess = getProcessForPort(DEFAULT_PORT);
-    var question = chalk.yellow(
-      'Something is already running on port ' +
-        DEFAULT_PORT +
-        '.' +
-        (existingProcess ? ' Probably:\n  ' + existingProcess : '')
-    ) + '\n\nWould you like to run the app on another port instead?';
+    var question =
+      chalk.yellow(
+        'Something is already running on port ' +
+          DEFAULT_PORT +
+          '.' +
+          (existingProcess ? ' Probably:\n  ' + existingProcess : '')
+      ) + '\n\nWould you like to run the app on another port instead?';
 
     prompt(question, true).then(shouldChangePort => {
       if (shouldChangePort) {

--- a/ui/scripts/test.js
+++ b/ui/scripts/test.js
@@ -5,7 +5,7 @@ process.env.PUBLIC_URL = '';
 // if this file is missing. dotenv will never modify any environment variables
 // that have already been set.
 // https://github.com/motdotla/dotenv
-require('dotenv').config({silent: true});
+require('dotenv').config({ silent: true });
 
 const jest = require('jest');
 const argv = process.argv.slice(2);
@@ -14,6 +14,5 @@ const argv = process.argv.slice(2);
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');
 }
-
 
 jest.run(argv);

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -25,36 +25,30 @@ const App = ({ store, history }: { store: mixed, history: mixed }) => {
     { path: '/traffic', icon: 'share-alt' },
     { path: '/about', icon: 'question' }
   ].concat(
-    plugins.reduce(
-      (acc, plugin) => {
-        if (plugin.name && plugin.icon) {
-          const name = plugin.name.replace('epl-', '');
-          return acc.concat({ path: `/${name}`, icon: plugin.icon });
-        }
-        console.warn(`Could not register navigation for ${plugin.name}`);
-        return acc;
-      },
-      []
-    )
+    plugins.reduce((acc, plugin) => {
+      if (plugin.name && plugin.icon) {
+        const name = plugin.name.replace('epl-', '');
+        return acc.concat({ path: `/${name}`, icon: plugin.icon });
+      }
+      console.warn(`Could not register navigation for ${plugin.name}`);
+      return acc;
+    }, [])
   );
 
-  const routes = plugins.reduce(
-    (acc, plugin) => {
-      if (plugin.name && plugin.Component) {
-        const name = plugin.name.replace('epl-', '');
-        return acc.concat(
-          <Route
-            key={acc.length}
-            path={`/${name}`}
-            component={plugin.Component}
-          />
-        );
-      }
-      console.warn(`Could not add route for ${plugin.name}`);
-      return acc;
-    },
-    []
-  );
+  const routes = plugins.reduce((acc, plugin) => {
+    if (plugin.name && plugin.Component) {
+      const name = plugin.name.replace('epl-', '');
+      return acc.concat(
+        <Route
+          key={acc.length}
+          path={`/${name}`}
+          component={plugin.Component}
+        />
+      );
+    }
+    console.warn(`Could not add route for ${plugin.name}`);
+    return acc;
+  }, []);
 
   return (
     <Provider store={store}>

--- a/ui/src/core/components/Footer.js
+++ b/ui/src/core/components/Footer.js
@@ -11,10 +11,10 @@ type Props = {
 };
 
 const Footer = ({ node, connection }: Props) => {
-  const color = ({
+  const color = {
     connected: '#227A50',
     disconnected: '#C13035'
-  })[connection];
+  }[connection];
 
   return (
     <div className="Footer text-right">
@@ -22,11 +22,9 @@ const Footer = ({ node, connection }: Props) => {
         id="footer-node"
         title="Node"
         popover={
-          (
-            <span>
-              Connected to: <strong>{node}</strong>
-            </span>
-          )
+          <span>
+            Connected to: <strong>{node}</strong>
+          </span>
         }
         item={<span>{node}</span>}
       />
@@ -35,11 +33,9 @@ const Footer = ({ node, connection }: Props) => {
         id="footer-connectionn"
         title="Connection"
         popover={
-          (
-            <span>
-              Status: <strong style={{ color }}>{connection}</strong>
-            </span>
-          )
+          <span>
+            Status: <strong style={{ color }}>{connection}</strong>
+          </span>
         }
         item={<i className="fa fa-plug" style={{ color }} />}
       />
@@ -47,12 +43,9 @@ const Footer = ({ node, connection }: Props) => {
   );
 };
 
-export default connect(
-  state => {
-    return {
-      node: state.core.node,
-      connection: state.core.connection
-    };
-  },
-  {}
-)(Footer);
+export default connect(state => {
+  return {
+    node: state.core.node,
+    connection: state.core.connection
+  };
+}, {})(Footer);

--- a/ui/src/core/components/FooterItem.js
+++ b/ui/src/core/components/FooterItem.js
@@ -17,11 +17,9 @@ const FooterItem = ({ title, item, popover, id }: Props) => {
         trigger={['hover']}
         placement="top"
         overlay={
-          (
-            <Popover id={id} title={title}>
-              {popover}
-            </Popover>
-          )
+          <Popover id={id} title={title}>
+            {popover}
+          </Popover>
         }
       >
         {item}

--- a/ui/src/plugins.js
+++ b/ui/src/plugins.js
@@ -10,7 +10,8 @@ if (process.env.NODE_ENV !== 'production') {
 const plugins = Object.keys(window)
   .filter(key => {
     return key.match(/^__EPL_/);
-  }).map(key => console.log('Loaded:', key.replace('__EPL_', '')) || window[key]);
+  })
+  .map(key => console.log('Loaded:', key.replace('__EPL_', '')) || window[key]);
 
 console.log('Plugins found:', plugins);
 

--- a/ui/src/plugins/epl-dashboard/__tests__/reducer.test.js
+++ b/ui/src/plugins/epl-dashboard/__tests__/reducer.test.js
@@ -36,10 +36,8 @@ describe('systemOverview reducer', () => {
       memoryTotal: undefined,
       processCount: undefined
     };
-    const state = reducer(
-      undefined,
-      actions.updateSystemInfo(info)
-    ).systemOverview;
+    const state = reducer(undefined, actions.updateSystemInfo(info))
+      .systemOverview;
     expect(state.receive).toHaveLength(0);
     expect(state.memoryTotal).toHaveLength(0);
     expect(state.processCount).toHaveLength(0);

--- a/ui/src/plugins/epl-dashboard/components/Loader.js
+++ b/ui/src/plugins/epl-dashboard/components/Loader.js
@@ -5,7 +5,7 @@ import './Loader.css';
 
 type Props = {
   text: string,
-  style: any,
+  style: any
 };
 
 const Loader = ({ text, style }: Props) => {

--- a/ui/src/plugins/epl-dashboard/components/SystemInfo.js
+++ b/ui/src/plugins/epl-dashboard/components/SystemInfo.js
@@ -56,9 +56,6 @@ const SystemInfo = ({ info }) => {
   );
 };
 
-export default connect(
-  state => {
-    return { info: state.eplDashboard.systemInfo };
-  },
-  {}
-)(SystemInfo);
+export default connect(state => {
+  return { info: state.eplDashboard.systemInfo };
+}, {})(SystemInfo);

--- a/ui/src/plugins/epl-dashboard/components/SystemOverview.js
+++ b/ui/src/plugins/epl-dashboard/components/SystemOverview.js
@@ -129,12 +129,9 @@ class SystemOverview extends Component {
   }
 }
 
-export default connect(
-  state => {
-    return {
-      info: state.eplDashboard.systemInfo,
-      overview: state.eplDashboard.systemOverview
-    };
-  },
-  {}
-)(SystemOverview);
+export default connect(state => {
+  return {
+    info: state.eplDashboard.systemInfo,
+    overview: state.eplDashboard.systemOverview
+  };
+}, {})(SystemOverview);

--- a/ui/src/plugins/epl-dashboard/components/SystemOverviewChart.js
+++ b/ui/src/plugins/epl-dashboard/components/SystemOverviewChart.js
@@ -24,19 +24,17 @@ type Props = {
   xAxisDataKey?: string
 };
 
-const SystemOverviewChart = (
-  {
-    data,
-    color,
-    title,
-    width,
-    height,
-    dataKey,
-    xAxisDataKey,
-    loaderText,
-    domain
-  }: Props
-) => {
+const SystemOverviewChart = ({
+  data,
+  color,
+  title,
+  width,
+  height,
+  dataKey,
+  xAxisDataKey,
+  loaderText,
+  domain
+}: Props) => {
   return (
     <Col xs={12}>
       <h5 className="SystemInfo-list-header">

--- a/ui/src/plugins/epl-dashboard/sockets.js
+++ b/ui/src/plugins/epl-dashboard/sockets.js
@@ -4,13 +4,15 @@ import humps from 'humps';
 import { onWithStore } from '../../sockets';
 import * as actions from './actions';
 
-export default onWithStore((store, on) => on('epl_dashboard_EPL', {
-  'system-init': data => {
-    const d = humps.camelizeKeys(data);
-    store.dispatch(actions.updateSystemInfo(humps.camelizeKeys(d)));
-  },
-  'system-info': data => {
-    const d = humps.camelizeKeys(data);
-    store.dispatch(actions.updateSystemInfo(humps.camelizeKeys(d)));
-  }
-}));
+export default onWithStore((store, on) =>
+  on('epl_dashboard_EPL', {
+    'system-init': data => {
+      const d = humps.camelizeKeys(data);
+      store.dispatch(actions.updateSystemInfo(humps.camelizeKeys(d)));
+    },
+    'system-info': data => {
+      const d = humps.camelizeKeys(data);
+      store.dispatch(actions.updateSystemInfo(humps.camelizeKeys(d)));
+    }
+  })
+);

--- a/ui/src/plugins/epl-sup-tree/components/SupTree.js
+++ b/ui/src/plugins/epl-sup-tree/components/SupTree.js
@@ -255,7 +255,7 @@ class SupTree extends Component {
             </div>
           </div>}
 
-        <div className="graph" ref={node => this.div = node} />
+        <div className="graph" ref={node => (this.div = node)} />
         <div className="side-panel">
 
           <div className="head" onClick={this.toggleCollapse}>

--- a/ui/src/plugins/epl-sup-tree/components/SupTree.js
+++ b/ui/src/plugins/epl-sup-tree/components/SupTree.js
@@ -87,13 +87,11 @@ class SupTree extends Component {
 
     events.click(({ id }) => this.selectNode(id));
 
-    setTimeout(
-      () => {
-        this.setState({ renderer, graph, graphics, layout, events }, () =>
-          this.propagateGraph());
-      },
-      0
-    );
+    setTimeout(() => {
+      this.setState({ renderer, graph, graphics, layout, events }, () =>
+        this.propagateGraph()
+      );
+    }, 0);
   }
 
   selectNode(id: string, center: ?boolean) {
@@ -139,31 +137,28 @@ class SupTree extends Component {
 
     let appsNodes = []; //this.state.appsNodes;
 
-    const list = Object.keys(props.tree).reduce(
-      (acc, app) => {
-        const parent = props.tree[app];
-        if (Object.keys(parent).length) {
-          if (all.indexOf(parent.id) < 0) {
-            const app = this.state.graph.addNode(parent.id, { ...parent });
-            if (!this.state.appsNodes.includes(app)) {
-              appsNodes.push(app);
-            }
+    const list = Object.keys(props.tree).reduce((acc, app) => {
+      const parent = props.tree[app];
+      if (Object.keys(parent).length) {
+        if (all.indexOf(parent.id) < 0) {
+          const app = this.state.graph.addNode(parent.id, { ...parent });
+          if (!this.state.appsNodes.includes(app)) {
+            appsNodes.push(app);
           }
-
-          return acc
-            .concat(parent.id)
-            .concat(
-              parent.children.reduce(
-                (acc, child) => acc.concat(this.mapChild(child, parent)),
-                []
-              )
-            );
         }
 
-        return acc;
-      },
-      []
-    );
+        return acc
+          .concat(parent.id)
+          .concat(
+            parent.children.reduce(
+              (acc, child) => acc.concat(this.mapChild(child, parent)),
+              []
+            )
+          );
+      }
+
+      return acc;
+    }, []);
 
     if (this.state.first && Object.keys(props.tree).length) {
       this.state.renderer.run();
@@ -300,7 +295,7 @@ class SupTree extends Component {
                       </ListGroupItem>
                       {Object.keys(this.props.tree).map(
                         (app, key) =>
-                          Object.keys(this.props.tree[app]).length
+                          (Object.keys(this.props.tree[app]).length
                             ? <ListGroupItem
                                 key={key}
                                 className="application-link"
@@ -332,7 +327,7 @@ class SupTree extends Component {
                                 <span style={{ marginLeft: '17px' }}>
                                   {app}
                                 </span>
-                              </ListGroupItem>
+                              </ListGroupItem>)
                       )}
                     </ListGroup>
                   </div>}

--- a/ui/src/plugins/epl-vizceral/components/Traffic.js
+++ b/ui/src/plugins/epl-vizceral/components/Traffic.js
@@ -96,7 +96,7 @@ class Traffic extends Component {
               >
 
                 <Vizceral
-                  ref={node => this.vizceral = node}
+                  ref={node => (this.vizceral = node)}
                   traffic={this.props.data}
                   view={this.props.view}
                   viewChanged={this.handleViewChange}

--- a/ui/src/reducer.js
+++ b/ui/src/reducer.js
@@ -11,19 +11,16 @@ import eplVizceral from './plugins/epl-vizceral';
 
 import plugins from './plugins';
 
-const reducers = plugins.reduce(
-  (acc, plugin) => {
-    if (plugin.reducer && plugin.name) {
-      return {
-        ...acc,
-        [plugin.name]: plugin.reducer
-      };
-    }
-    console.warn(`Could not register reducer for ${plugin.name}`);
-    return acc;
-  },
-  {}
-);
+const reducers = plugins.reduce((acc, plugin) => {
+  if (plugin.reducer && plugin.name) {
+    return {
+      ...acc,
+      [plugin.name]: plugin.reducer
+    };
+  }
+  console.warn(`Could not register reducer for ${plugin.name}`);
+  return acc;
+}, {});
 
 export default combineReducers({
   core: core.reducer,

--- a/ui/src/sockets.js
+++ b/ui/src/sockets.js
@@ -45,9 +45,9 @@ export const combineSockets = (
       return socket;
     })
     .reduce((acc, { route, topics, builtIn }) => {
-      const concatenatedTopics = Object.keys(topics).reduce((acc: {
-        [key: string]: Array<() => void>
-      }, topic: string) => {
+      const concatenatedTopics = Object.keys(
+        topics
+      ).reduce((acc: { [key: string]: Array<() => void> }, topic: string) => {
         return {
           ...acc,
           [topic]: (acc[topic] || []).concat(topics[topic])

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,7 +72,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -88,6 +88,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  dependencies:
+    color-convert "^1.0.0"
+
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
@@ -98,6 +104,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -180,6 +190,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+ast-types@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -225,7 +239,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@6.22.0, babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -871,6 +885,10 @@ babel-types@^6.15.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babylon@7.0.0-beta.8:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
+
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
@@ -1126,17 +1144,28 @@ clean-css@4.0.x:
   dependencies:
     source-map "0.5.x"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
 
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
   dependencies:
     colors "1.0.3"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-usage@^0.1.1:
   version "0.1.4"
@@ -1183,7 +1212,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-color-convert@^1.3.0:
+color-convert@^1.0.0, color-convert@^1.3.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -1345,6 +1374,19 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.1.1.tgz#817f2c2039347a1e9bf7d090c0923e53f749ca82"
@@ -1375,6 +1417,14 @@ cross-spawn@4.0.2:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -1570,6 +1620,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.27.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.2.tgz#19e4192d68875c0bf7c9537e3f296a8ec64853ef"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -1734,6 +1788,10 @@ ee-first@1.1.1:
 electron-to-chromium@^1.1.0, electron-to-chromium@^1.2.7:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.3.tgz#651eb63fe89f39db70ffc8dbd5d9b66958bc6a0e"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 elm-webpack-loader@^4.3.0:
   version "4.3.0"
@@ -2011,7 +2069,7 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -2045,6 +2103,18 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -2161,7 +2231,7 @@ fbjs@^0.8.4, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2233,6 +2303,10 @@ find-elm-dependencies@1.0.1:
     firstline "1.2.0"
     lodash "4.14.2"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
 find-up@^1.0.0, find-up@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2260,6 +2334,10 @@ flatten@^1.0.2:
 flow-bin@^0.39.0:
   version "0.39.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.39.0.tgz#b1012a14460df1aa79d3a728e10f93c6944226d0"
+
+flow-parser@0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
 
 font-awesome@^4.7.0:
   version "4.7.0"
@@ -2386,6 +2464,14 @@ get-node-dimensions@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/get-node-dimensions/-/get-node-dimensions-1.2.2.tgz#7a71e8624cf9e1ab74599bb05b7e5116e995e45b"
 
+get-stdin@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -2409,17 +2495,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@7.1.1, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2427,6 +2503,16 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2655,6 +2741,15 @@ humps@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.0.tgz#dd4a423e9784626fe7b9f19fde0baff659b40173"
 
+husky@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.3.tgz#bc2066080badc8b8fe3516e881f5bc68a57052ff"
+  dependencies:
+    chalk "^1.1.3"
+    find-parent-dir "^0.3.0"
+    is-ci "^1.0.9"
+    normalize-path "^1.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -2678,6 +2773,16 @@ ignore@^3.1.5:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -2865,6 +2970,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -2875,7 +2984,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3089,6 +3198,13 @@ jest-matcher-utils@^18.1.0:
     chalk "^1.1.3"
     pretty-format "^18.1.0"
 
+jest-matcher-utils@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^19.0.0"
+
 jest-matchers@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-18.1.0.tgz#0341484bf87a1fd0bac0a4d2c899e2b77a3f1ead"
@@ -3159,6 +3275,15 @@ jest-util@^18.1.0:
     jest-file-exists "^17.0.0"
     jest-mock "^18.0.0"
     mkdirp "^0.5.1"
+
+jest-validate@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^19.0.0"
+    leven "^2.0.0"
+    pretty-format "^19.0.0"
 
 jest@18.1.0:
   version "18.1.0"
@@ -3311,12 +3436,74 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leven@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lint-staged@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.4.0.tgz#52fa85dfc92bb1c6fe8ad0d0d98ca13924e03e4b"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.6.0"
+    listr "^0.11.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.11.0.tgz#5e778bc23806ac3ab984ed75564458151f39b03e"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -3445,6 +3632,19 @@ lodash@4.14.2:
 "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3581,7 +3781,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3802,6 +4002,10 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -3820,6 +4024,26 @@ normalize-url@^1.4.0:
     prepend-http "^1.0.0"
     query-string "^4.1.0"
     sort-keys "^1.0.0"
+
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.0.2"
@@ -3916,6 +4140,15 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 original@>=0.0.5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.0.tgz#9147f93fa1696d04be61e01bd50baeaca656bd3b"
@@ -3946,6 +4179,10 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -3997,6 +4234,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -4340,6 +4581,21 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.0.2.tgz#84535548fca00cf0acd7ca8296d492352ef167d7"
+  dependencies:
+    ast-types "0.9.8"
+    babel-code-frame "6.22.0"
+    babylon "7.0.0-beta.8"
+    chalk "1.1.3"
+    esutils "2.0.2"
+    flow-parser "0.43.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "19.0.0"
+    minimist "1.2.0"
+
 pretty-error@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.0.tgz#87f4e9d706a24c87d6cbee9fabec001fcf8c75d8"
@@ -4352,6 +4608,12 @@ pretty-format@^18.1.0:
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-18.1.0.tgz#fb65a86f7a7f9194963eee91865c1bcf1039e284"
   dependencies:
     ansi-styles "^2.2.1"
+
+pretty-format@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
+  dependencies:
+    ansi-styles "^3.0.0"
 
 private@^0.1.6:
   version "0.1.7"
@@ -4945,6 +5207,12 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rxjs@^5.0.0-beta.11:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.0.tgz#d88ccbdd46af290cbdb97d5d8055e52453fabe2d"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -5030,6 +5298,16 @@ setprototypeof@1.0.3:
 sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.6.0:
   version "0.6.1"
@@ -5157,6 +5435,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -5181,6 +5463,10 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -5235,6 +5521,10 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-json-comments@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
@@ -5271,7 +5561,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.2:
+symbol-observable@^1.0.1, symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -5749,7 +6039,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.0.5, which@^1.1.1, which@^1.2.9:
+which@^1.0.5, which@^1.1.1, which@^1.2.10, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,6 +919,22 @@ binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
+"binary@>= 0.3.0 < 1":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
+
+binwrap@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/binwrap/-/binwrap-0.1.4.tgz#ca1f7870302212518fa24b07726f9c50a15c7559"
+  dependencies:
+    request "^2.81.0"
+    request-promise "^4.2.0"
+    tar "^2.2.1"
+    unzip "^0.1.11"
+
 bl@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.1.2.tgz#fdca871a99713aa00d19e3bbba41c44787a65398"
@@ -935,7 +951,7 @@ bluebird@^2.10.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
-bluebird@^3.4.6:
+bluebird@^3.4.6, bluebird@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
@@ -1010,6 +1026,10 @@ buffer@^4.9.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -1090,6 +1110,12 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  dependencies:
+    traverse ">=0.3.0 <0.4"
 
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -1793,6 +1819,12 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
+elm-format@^0.6.1-alpha:
+  version "0.6.1-alpha"
+  resolved "https://registry.yarnpkg.com/elm-format/-/elm-format-0.6.1-alpha.tgz#daeffe95238cb8ce0d7fc6afb5047bcdd14ad7d7"
+  dependencies:
+    binwrap "^0.1.4"
+
 elm-webpack-loader@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/elm-webpack-loader/-/elm-webpack-loader-4.3.0.tgz#796d391794b44aac6b865d9a5d045b597e486117"
@@ -2420,6 +2452,15 @@ fstream-ignore@^1.0.5:
     inherits "2"
     minimatch "^3.0.0"
 
+"fstream@>= 0.1.30 < 1":
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-0.1.31.tgz#7337f058fbbbbefa8c9f561a28cab0849202c988"
+  dependencies:
+    graceful-fs "~3.0.2"
+    inherits "~2.0.0"
+    mkdirp "0.5"
+    rimraf "2"
+
 fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
@@ -2534,6 +2575,12 @@ globby@^5.0.0:
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graceful-fs@~3.0.2:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
+  dependencies:
+    natives "^1.1.0"
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -3629,7 +3676,7 @@ lodash@4.14.2:
   version "4.14.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.14.2.tgz#bbccce6373a400fbfd0a8c67ca42f6d1ef416432"
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3690,6 +3737,13 @@ marked-terminal@^1.6.2:
 marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
+"match-stream@>= 0.0.2 < 1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/match-stream/-/match-stream-0.0.2.tgz#99eb050093b34dffade421b9ac0b410a9cfa17cf"
+  dependencies:
+    buffers "~0.1.1"
+    readable-stream "~1.0.0"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.16"
@@ -3785,7 +3839,7 @@ minimist@1.2.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5, mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3806,6 +3860,10 @@ mute-stream@0.0.5:
 nan@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.1.tgz#8c84f7b14c96b89f57fbc838012180ec8ca39a01"
+
+natives@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4179,6 +4237,10 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+"over@>= 0.0.5 < 1":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/over/-/over-0.0.5.tgz#f29852e70fd7e25f360e013a8ec44c82aedb5708"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -4581,9 +4643,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.0.2.tgz#84535548fca00cf0acd7ca8296d492352ef167d7"
+prettier@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.2.2.tgz#22d17c1132faaaea1f1d4faea31f19f7a1959f3e"
   dependencies:
     ast-types "0.9.8"
     babel-code-frame "6.22.0"
@@ -4657,6 +4719,15 @@ prr@~0.0.0:
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+"pullstream@>= 0.4.1 < 1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/pullstream/-/pullstream-0.4.1.tgz#d6fb3bf5aed697e831150eb1002c25a3f8ae1314"
+  dependencies:
+    over ">= 0.0.5 < 1"
+    readable-stream "~1.0.31"
+    setimmediate ">= 1.0.2 < 2"
+    slice-stream ">= 1.0.0 < 2"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -4883,7 +4954,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@1.0:
+readable-stream@1.0, readable-stream@~1.0.0, readable-stream@~1.0.31:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
@@ -5071,6 +5142,20 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.0.tgz#684f77748d6b4617bee6a4ef4469906e6d074720"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.1"
+    stealthy-require "^1.0.0"
 
 request@2.74.0:
   version "2.74.0"
@@ -5283,7 +5368,7 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+"setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2", setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
@@ -5334,6 +5419,12 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+"slice-stream@>= 1.0.0 < 2":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-stream/-/slice-stream-1.0.0.tgz#5b33bd66f013b1a7f86460b03d463dec39ad3ea0"
+  dependencies:
+    readable-stream "~1.0.31"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -5442,6 +5533,10 @@ staged-git-files@0.0.4:
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
+stealthy-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.0.0.tgz#1a8ed8fc19a8b56268f76f5a1a3e3832b0c26200"
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -5670,6 +5765,10 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -5770,6 +5869,17 @@ uniqs@^2.0.0:
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+unzip@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/unzip/-/unzip-0.1.11.tgz#89749c63b058d7d90d619f86b98aa1535d3b97f0"
+  dependencies:
+    binary ">= 0.3.0 < 1"
+    fstream ">= 0.1.30 < 1"
+    match-stream ">= 0.0.2 < 1"
+    pullstream ">= 0.4.1 < 1"
+    readable-stream "~1.0.31"
+    setimmediate ">= 1.0.1 < 2"
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
[Prettier](https://github.com/prettier/prettier) is an awesome tool for JS code formatting. We were requiring it in our README section in old UI repo.

Recently version 1.0 of prettier come out so I thought it's a good moment to add it as pre-commit hook.

I want to add similar thing for Elm later: https://github.com/avh4/elm-format