### PR TITLE
Add make release rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # allow rebar binary to be set via environment variable
 REBAR ?= ./rebar
 
+
 all:
 	@$(REBAR) get-deps compile
 
@@ -29,6 +30,13 @@ rebar:
 	chmod +x $@
 
 ui:
-	rm -rf apps/epl/priv/htdocs
-	yarn && yarn build
-	mv build apps/epl/priv/htdocs
+	@rm -rf apps/epl/priv/htdocs
+	@yarn && yarn build
+	@mv build apps/epl/priv/htdocs
+
+release:
+	@echo "Building release version of Erlang Performance Lab"
+	@make rebar
+	@make ui
+	@make
+	@./bootstrap

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 # allow rebar binary to be set via environment variable
 REBAR ?= ./rebar
 
-
-all:
+all: rebar
 	@$(REBAR) get-deps compile
 
 test: compile
@@ -34,9 +33,5 @@ ui:
 	@yarn && yarn build
 	@mv build apps/epl/priv/htdocs
 
-release:
-	@echo "Building release version of Erlang Performance Lab"
-	@make rebar
-	@make ui
-	@make
+release: all ui
 	@./bootstrap

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ download for the first time. Second time dependencies will be cached.
 ```
 $ git clone https://github.com/erlanglab/erlangpl.git
 $ cd erlangpl
-$ make rebar
-$ make ui
-$ make
-$ ./bootstrap
+$ make release
 ```
 
 ## Running erlangpl script


### PR DESCRIPTION
Building Erlang Perf Lab manually requires few commands to run. I propose new rule which contains all commands which are necessary to run.

I'm not an Make expert so I'm counting on your review 🙂