### PR TITLE
Fix logging in run1 stage

### DIFF
--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -88,7 +88,7 @@ run1() ->
             Args = filter_flags(NonOptArgs, []),
             Options ++ Args;
         {error, {Reason, Data}} ->
-            ?ERROR("~s ~p~n", [Reason, Data]),
+            ?CONSOLE("ERROR: ~s ~p~n", [Reason, Data]),
             help()
     end.
 


### PR DESCRIPTION
(candidate for smallest PR price)

In startup stage run1 the log level is not yet initialized (because it
depends on the arguments) therefore it is not possible to emit an error
log. In case of some issue with argument parsing write instead to
console directly.

This eliminates the below error:

    exited: {bad_return,
                {{epl_app,start,[normal,[]]},
                 {'EXIT',
                     {badarg,
                         [{ets,lookup,[epl_priv,log_level],[]},
                          {epl,lookup,1,[{file,"src/epl.erl"},{line,27}]},
                          {epl,log,3,[{file,"src/epl.erl"},{line,63}]},
                          {epl_app,run1,0,
                              [{file,"src/epl_app.erl"},{line,91}]},
                          {epl_app,start,2,
                              [{file,"src/epl_app.erl"},{line,22}]},
                          {application_master,start_it_old,4,
                              [{file,"application_master.erl"},
                               {line,273}]}]}}}}