### PR TITLE
Use Cowboy 1.1.2

### DIFF
--- a/apps/epl/rebar.config
+++ b/apps/epl/rebar.config
@@ -3,7 +3,7 @@
 {deps, [{getopt, ".*",
          {git, "git://github.com/jcomellas/getopt.git", "master"}},
         {cowboy, ".*",
-         {git, "git://github.com/ninenines/cowboy.git", "0.8.5"}},
+         {git, "git://github.com/ninenines/cowboy.git", "1.1.2"}},
         {jsone, ".*",
          {git, "git://github.com/erlanglab/jsone.git", "master"}}
        ]

--- a/apps/epl/src/erlangpl.erl
+++ b/apps/epl/src/erlangpl.erl
@@ -11,13 +11,8 @@
 -export([main/1]).
 
 main(_) ->
-    ok = application:start(crypto),
-    ok = application:start(getopt),
-    ok = application:start(ranch),
-    ok = application:start(cowboy),
-    ok = application:start(jsone),
-    ok = application:start(epl),
-    ok = application:start(epl_st),
+    {ok, _} = application:ensure_all_started(epl),
+    {ok, _} = application:ensure_all_started(epl_st),
 
     %% Start applications because escript can't take -boot argument
     %% TODO: start sasl if escript run with debug flags

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -16,7 +16,11 @@
          jsone,
          runtime_tools,
          epl,
-         epl_st
+         epl_st,
+         asn1,
+         cowlib,
+         public_key,
+         ssl
         ]},
        {rel, "start_clean", "",
         [
@@ -35,7 +39,11 @@
        {app, sasl, [{incl_cond, include}]},
        {app, crypto,   [{incl_cond, include}]},
        {app, getopt,   [{incl_cond, include}]},
+       {app, asn1,   [{incl_cond, include}]},
+       {app, public_key, [{incl_cond, include}]},
+       {app, ssl, [{incl_cond, include}]},
        {app, ranch, [{incl_cond, include}]},
+       {app, cowlib,   [{incl_cond, include}]},
        {app, cowboy, [{incl_cond, include}]},
        {app, jsone, [{incl_cond, include}]},
        {app, runtime_tools, [{incl_cond, include}]},


### PR DESCRIPTION
This PR updates Cowboy dependency to 1.1.2.

Upgrading Cowbow added lots of dependencies, which made both reltool and our escript unhappy. To make at least escript happy, I've changes applications' starting method to `application:ensure_all_started/1`.

Closes #58