### PR TITLE
[WIP] Cluster traffic

### DIFF
--- a/apps/epl/src/epl_app.erl
+++ b/apps/epl/src/epl_app.erl
@@ -348,7 +348,7 @@ set_log_level(Verbose) when is_integer(Verbose) ->
     true = ets:insert(epl_priv, {log_level, LogLevel}).
 
 start_distributed(Args) ->
-    application:set_env(kernel, dist_auto_connect, never),
+    %% application:set_env(kernel, dist_auto_connect, never),
 
     %% By default we start as -name erlangpl@127.0.0.1
     %% if --sname or --name flag was passed, we start accordingly

--- a/apps/epl/src/epl_traffic.erl
+++ b/apps/epl/src/epl_traffic.erl
@@ -130,12 +130,17 @@ get_cluster_traffic_counters(Nodes) ->
     %%          {type,normal},
     %%          {in,32},
     %%          {out,22}]}]}
-    lists:flatten(
+    DataFlowInfo = lists:flatten(
       lists:map(fun({NodeA, NeighboursInfo}) ->
                         [{{NodeA, NodeB}, NodeIn, NodeOut} ||
                             {NodeB, [_, _, _, _,{in,NodeIn}, {out,NodeOut}]}
                                 <- NeighboursInfo]
-                end, NodesInfo)).
+                end, NodesInfo)),
+    Self = node(),
+    lists:filter(fun({{NodeA, NodeB}, _, _})
+		       when NodeA =/= Self andalso NodeB =/= Self -> true;
+		    (_) -> false
+		 end, DataFlowInfo).
 
 terminate(_Reason, _State) ->
     ok.


### PR DESCRIPTION
### Redesign of the traffic plugin

Make the 1st level view of Vizceral render network traffic between the Internet and all nodes in the cluster.

If in the 1st level one clicks on the central circle, which represents the Internet, make the 2nd level view render network traffic between nodes in the cluster. The 3rd level view in this case is a zoom to a node and preferably also some extra information about the node, e.g. button to make it the default node, so that the dashboard view can render more details.

If in the 1st level a circle other than the central one is clicked, render message passing between processes running in that node. 3rd level view in this case is a zoom to a process and preferably also some extra information about the process, e.g. button to enable timeline tracking.