### PR TITLE
Make ETS node view work with OTP 20

### DIFF
--- a/apps/epl/src/epl_viz_map.erl
+++ b/apps/epl/src/epl_viz_map.erl
@@ -157,6 +157,9 @@ binarify(Name) when is_port(Name) ->
     list_to_binary(erlang:port_to_list(Name));
 binarify(Name) when is_integer(Name) ->
     integer_to_binary(Name);
+binarify(Name) when is_reference(Name) ->
+    [RefBin] = io_lib:format("~p", [Name]),
+    RefBin;
 binarify(Name) when is_binary(Name) ->
     Name.
 

--- a/apps/epl/src/epl_viz_map.erl
+++ b/apps/epl/src/epl_viz_map.erl
@@ -159,7 +159,7 @@ binarify(Name) when is_integer(Name) ->
     integer_to_binary(Name);
 binarify(Name) when is_reference(Name) ->
     [RefBin] = io_lib:format("~p", [Name]),
-    RefBin;
+    binarify(RefBin);
 binarify(Name) when is_binary(Name) ->
     Name.
 


### PR DESCRIPTION
This PR makes it possible to work ETS node view with OTP 20. Latest version (0.8.0) of ErlangPL does not work properly with OTP 20 because ETS tables identifiers are references in this version of Erlang.