### PR TITLE
Prevent ETS node view error when trying to enable/disable ETS tracing on a dead node

### DIFF
--- a/apps/epl_ets/src/epl_ets_EPL.erl
+++ b/apps/epl_ets/src/epl_ets_EPL.erl
@@ -54,8 +54,18 @@ websocket_terminate(_Reason, _Req, #state{ets_call_traced_nodes = TNodes}) ->
 %%====================================================================
 
 handle_ets_call_tracing(Node, Nodes, true) ->
-    ok = epl_tracer:disable_ets_call_tracing(Node),
+    ok = disable_ets_call_tracing(Node, whereis(Node)),
     lists:delete(Node, Nodes);
 handle_ets_call_tracing(Node, Nodes, false) ->
-    ok = epl_tracer:enable_ets_call_tracing(Node),
+    ok = enable_ets_call_tracing(Node, whereis(Node)),
     [Node | Nodes].
+
+enable_ets_call_tracing(_Node, undefined) ->
+    ok;
+enable_ets_call_tracing(Node, _) ->
+    epl_tracer:enable_ets_call_tracing(Node).
+
+disable_ets_call_tracing(_Node, undefined) ->
+    ok;
+disable_ets_call_tracing(Node, _) ->
+    epl_tracer:disable_ets_call_tracing(Node).

--- a/apps/epl_ets/src/epl_ets_EPL.erl
+++ b/apps/epl_ets/src/epl_ets_EPL.erl
@@ -46,7 +46,7 @@ websocket_info(Info, _Req, _State) ->
 
 websocket_terminate(_Reason, _Req, #state{ets_call_traced_nodes = TNodes}) ->
     epl_ets:unsubscribe(),
-    [epl_tracer:disable_ets_call_tracing(N) || N <- TNodes],
+    [disable_ets_call_tracing(N, whereis(N)) || N <- TNodes],
     ok.
 
 %%====================================================================


### PR DESCRIPTION
It takes some time to clean dead node form a Vizceral graph, so there might be a situation when a user clicks on a node in Vizceral graph and the node is already dead. Click on a node cause ErlangPL try to enable/disable ETS tracing for that node and if it's dead it might be a problem. This PR prevents this kind of errors.