### PR TITLE
Add the feature of viewing traffic inside every node in the cluster

### DIFF
--- a/apps/epl/src/epl_traffic.erl
+++ b/apps/epl/src/epl_traffic.erl
@@ -91,7 +91,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 verify_subscribe_reply(Reply) ->
-    lists:all(fun(X) -> X =:= ok end, Reply).
+    lists:all(fun(R) -> R =:= ok end, Reply).
 
 verify_if_node_is_default(Node) ->
     verify_if_node_is_default(Node, epl:get_default_node()).
@@ -135,19 +135,9 @@ maybe_merge_focused_nodes_and_conns(#{name := Node}, Viz, OldViz) ->
 
 merge_focused_nodes_and_conns(_Node, Viz, []) ->
     Viz;
-merge_focused_nodes_and_conns(Node, Viz, #{nodes := OldFocusedNodes,
-                                           connections := OldFocusedConns}) ->
-    {Region, Viz2 = #{nodes := Regions}} = epl_viz_map:pull_region(Node, Viz),
-    RegionNodes = finally_merge_focused_nodes(Region, OldFocusedNodes),
-    RegionNodesAndConns = finally_merge_focused_conns(RegionNodes,
-                                                      OldFocusedConns),
-    finally_merge_focused_nodes_and_conns(Viz2, RegionNodesAndConns, Regions).
-
-finally_merge_focused_nodes(Region, OldFocusedNodes) ->
-    maps:merge(Region, #{nodes => OldFocusedNodes}).
-
-finally_merge_focused_conns(Region, OldFocusedConns) ->
-    maps:merge(Region, #{connections => OldFocusedConns}).
+merge_focused_nodes_and_conns(Node, Viz, Region) ->
+    {_, Viz2 = #{nodes := Regions}} = epl_viz_map:pull_region(Node, Viz),
+    finally_merge_focused_nodes_and_conns(Viz2, Region, Regions).
 
 finally_merge_focused_nodes_and_conns(Viz, UpdatedRegion, Regions) ->
     maps:merge(Viz, #{nodes => [UpdatedRegion | Regions]}).

--- a/apps/epl/src/epl_viz_map.erl
+++ b/apps/epl/src/epl_viz_map.erl
@@ -19,7 +19,7 @@
          push_focused/4,
          push_focused_connection/5,
          push_focused_connection/6,
-         clear_focused_nodes_inside_region/2,
+         clear_focused_nodes_and_conns_inside_region/2,
          binarify/1,
          namify/1]).
 
@@ -146,10 +146,10 @@ push_focused_connection(Source, Target, RegionName, {N, W, D}, A, Vizceral) ->
     NewR = push_connection(Source, Target, {N,W,D}, A, Region),
     push_region(RegionName, NewR, NewV).
 
-%% @doc Clears all focused nodes from `RegionName` node.
--spec clear_focused_nodes_inside_region(RegionName :: name(), Viz :: map()) ->
+%% @doc Clears all focused nodes and connections from `RegionName` node.
+-spec clear_focused_nodes_and_conns_inside_region(RegionName :: name(), Viz :: map()) ->
   map().
-clear_focused_nodes_inside_region(RegionName, Viz) ->
+clear_focused_nodes_and_conns_inside_region(RegionName, Viz) ->
     {VizNode, NewViz = #{nodes := VizNodes}} =
         epl_viz_map:pull_region(RegionName, Viz),
     VizNodeCleared = maps:merge(VizNode, #{nodes => []}),

--- a/apps/epl_ets/src/epl_ets_viz_map.erl
+++ b/apps/epl_ets/src/epl_ets_viz_map.erl
@@ -27,13 +27,13 @@ update_cluster(Node, Viz = #{nodes := VizNodes}) ->
 %% @doc Updates the Vizceral map's ETS details section.
 -spec update_details(Node :: node(), [] | list(), Viz :: map()) -> map().
 update_details(Node, [], Viz) ->
-    VizCleaned = clean_ets_traffic_from_viz(Node, Viz),
-    push_ets_tables(undefined, Node, [], VizCleaned);
+    VizCleared = epl_viz_map:clear_focused_nodes_inside_region(Node, Viz),
+    push_ets_tables(undefined, Node, [], VizCleared);
 update_details(Node, ETSTrafficCounters, Viz) ->
-    VizCleaned = clean_ets_traffic_from_viz(Node, Viz),
+    VizCleared = epl_viz_map:clear_focused_nodes_inside_region(Node, Viz),
     {tab_traffic, ETSTraffic} =
         epl_ets_metric:get_ets_tab_traffic(ETSTrafficCounters),
-    push_tab_traffic(ETSTraffic, Node, VizCleaned).
+    push_tab_traffic(ETSTraffic, Node, VizCleared).
 
 %% @doc Removes outdated nodes from Vizceral map's cluster section.
 -spec remove_outdated(Nodes :: [#{atom() => integer()}], Viz :: map()) -> map().
@@ -108,13 +108,6 @@ ensure_traffic_metrics_are_num(undefined, undefined) ->
     {0, 0};
 ensure_traffic_metrics_are_num(Insert, Lookup) ->
     {Insert, Lookup}.
-
-clean_ets_traffic_from_viz(Node, Viz) ->
-    {VizNode, NewViz = #{nodes := VizNodes}} = epl_viz_map:pull_region(Node,
-                                                                       Viz),
-    VizNodeCleaned = maps:merge(VizNode, #{nodes => []}),
-    VizNodeCleaned2 = maps:merge(VizNodeCleaned, #{connections => []}),
-    maps:merge(NewViz, #{nodes => [VizNodeCleaned2 | VizNodes]}).
 
 get_node_ets_basic_info(Node) ->
     ETSCount = epl_ets_metric:get_node_ets_num(Node),

--- a/apps/epl_ets/src/epl_ets_viz_map.erl
+++ b/apps/epl_ets/src/epl_ets_viz_map.erl
@@ -27,10 +27,12 @@ update_cluster(Node, Viz = #{nodes := VizNodes}) ->
 %% @doc Updates the Vizceral map's ETS details section.
 -spec update_details(Node :: node(), [] | list(), Viz :: map()) -> map().
 update_details(Node, [], Viz) ->
-    VizCleared = epl_viz_map:clear_focused_nodes_inside_region(Node, Viz),
+    VizCleared = epl_viz_map:clear_focused_nodes_and_conns_inside_region(Node,
+                                                                         Viz),
     push_ets_tables(undefined, Node, [], VizCleared);
 update_details(Node, ETSTrafficCounters, Viz) ->
-    VizCleared = epl_viz_map:clear_focused_nodes_inside_region(Node, Viz),
+    VizCleared = epl_viz_map:clear_focused_nodes_and_conns_inside_region(Node,
+                                                                         Viz),
     {tab_traffic, ETSTraffic} =
         epl_ets_metric:get_ets_tab_traffic(ETSTrafficCounters),
     push_tab_traffic(ETSTraffic, Node, VizCleared).


### PR DESCRIPTION
It is now possible to view message passing inside each node in the cluster on the epl_traffic tab. In general, you can click on other nodes (not just default) and see traffic inside.

Major changes were made in epl_traffic module but I changed a bit epl_viz_map and epl_ets_viz_map modules. Details:
- Change epl_ets_viz_map:clean_ets_traffic_from_viz/2 function and move it to epl_viz_map in order to make it publicly accessible for the future use.
- Modify epl_viz_map:pull_node/2 so that it does not crash when the pulled node does not exist,
- Subscribe epl_traffic to all tracers and add functions which make it possible to create Vizceral map with data from all nodes. The map is still sent to epl_traffic subscribers every 5 seconds which is the moment it gets the message from the default_node. To wrap it up, this solution allows epl_traffic to build, manipulate and update the Vizceral map with data from all nodes and sents it out with all details about all nodes included. 

Issues with the view of nodes which are not default_node - graphic representations of processes are sometimes overlap or the view is almost empty. I think that it can by caused by lack of message passing in the observed nodes. I watched the traffic inside the nodes while running Mnesia example from README and it seems to work decently - I could see message passing between some Mnesia processes.

Guys, please let me know what you think :) @michalslaski @arkgil @Baransu @mkacper 

To be honest, it is my first contribution to a real project. Thanks to @mkacper for the introduction to ErlangPL and pair-programming sessions which enabled me to create this PR! :)